### PR TITLE
feat: cmake compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,5 +6,5 @@ set(CMAKE_CXX_FLAGS "-O3 -g3")
 
 set(CMAKE_CXX_STANDARD 17)
 
-add_library(symspell src/Symspell.cpp)
+add_library(symspell src/SymSpell.cpp)
 add_executable(symspelltest src/SymSpell.cpp SymSpellTest.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(symspell)
+cmake_minimum_required(VERSION 2.8)
+include_directories(include)
+
+set(CMAKE_CXX_FLAGS "-O3 -g3")
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_library(symspell src/Symspell.cpp)
+add_executable(symspelltest src/SymSpell.cpp SymSpellTest.cpp)

--- a/SymSpellTest.cpp
+++ b/SymSpellTest.cpp
@@ -3,7 +3,7 @@
 
 #include <iostream>
 #include <fcntl.h>
-#include <io.h>
+// #include <io.h>
 
 #ifdef UNICODE_SUPPORT
 
@@ -22,7 +22,7 @@ void TestJapanese()
 	xcout << XL("Library loaded: ") << time << XL(" ms") << endl;
 
 	xcout << XL("-------Testing Japanese word segmentation-------") << endl;
-	vector<xstring> sentences = { XL("“n•Ó“c’†"), XL("ŒÂ—Ñ“c’†"), XL("“n“ç‘½’†") };
+	vector<xstring> sentences = { XL("ï¿½nï¿½Ó“cï¿½ï¿½"), XL("ï¿½Â—Ñ“cï¿½ï¿½"), XL("ï¿½nï¿½ç‘½ï¿½ï¿½") };
 	for (int i = 0; i < sentences.size(); i++)
 	{
 		Info results = symSpell.WordSegmentation(sentences[i]);
@@ -30,7 +30,7 @@ void TestJapanese()
 	}
 
 	xcout << XL("-------Testing Japanese word correction-------") << endl;
-	sentences = { XL("˜j“ç"), XL("“c’†") };
+	sentences = { XL("ï¿½jï¿½ï¿½"), XL("ï¿½cï¿½ï¿½") };
 	for (int i = 0; i < sentences.size(); i++)
 	{
 		vector<SuggestItem> results = symSpell.Lookup(sentences[i], Verbosity::Closest);
@@ -52,7 +52,8 @@ void TestEnglish()
 	const int prefixLength = 3;
 	SymSpell symSpell(initialCapacity, maxEditDistance, prefixLength);
 	int start = clock();
-	symSpell.LoadDictionary("data\\frequency_dictionary_en_82_765.txt", 0, 1, XL(' '));
+	string corpus_path = "../data/frequency_dictionary_en_82_765.txt";
+	symSpell.LoadDictionary(corpus_path, 0, 1, XL(' '));
 	int end = clock();
 	float time = (float)((end - start) / (CLOCKS_PER_SEC / 1000));
 	xcout << XL("Library loaded: ") << time << XL(" ms") << endl;
@@ -86,9 +87,10 @@ void TestEnglish()
 	}
 }
 
-void main()
+int main()
 {
 	TestEnglish();
+	return 0;
 }
 
 #endif

--- a/include/Helpers.h
+++ b/include/Helpers.h
@@ -6,7 +6,7 @@
 #    else
 #        define LIBRARY_API __declspec(dllimport)
 #    endif
-#elif
+#else
 #    define LIBRARY_API
 #endif
 

--- a/src/SymSpell.cpp
+++ b/src/SymSpell.cpp
@@ -232,7 +232,7 @@ bool SymSpell::LoadBigramDictionary(xifstream& corpusStream, int termIndex, int 
 				
 			}catch(...) {
 				//maybe log something here
-				printf("Cannot convert %s to integer\n",lineParts[countIndex]);
+				printf("Cannot convert %s to integer\n", lineParts[countIndex].c_str());
 			}
 		}
 		else
@@ -627,7 +627,7 @@ vector<SuggestItem> SymSpell::Lookup(xstring input, Verbosity verbosity, int max
 		// \w Alphanumeric characters (including non-latin characters, umlaut characters and digits) plus "_" 
 		// \d Digits
 		// Compatible with non-latin characters, does not split words at apostrophes
-		xregex r(XL("['’\\w-\\[_\\]]+"));
+		xregex r(XL("['’\\w\\[_\\]]+"));
 		xsmatch m;
 		vector<xstring> matches;
 			//for benchmarking only: with CreateDictionary("big.txt","") and the text corpus from http://norvig.com/big.txt  the Regex below provides the exact same number of dictionary items as Norvigs regex "[a-z]+" (which splits words at apostrophes & incompatible with non-latin characters)     

--- a/src/SymSpell.cpp
+++ b/src/SymSpell.cpp
@@ -627,7 +627,7 @@ vector<SuggestItem> SymSpell::Lookup(xstring input, Verbosity verbosity, int max
 		// \w Alphanumeric characters (including non-latin characters, umlaut characters and digits) plus "_" 
 		// \d Digits
 		// Compatible with non-latin characters, does not split words at apostrophes
-		xregex r(XL("['’\\w\\[_\\]]+"));
+		xregex r(XL("['’\\w\\-\\[_\\]]+"));
 		xsmatch m;
 		vector<xstring> matches;
 			//for benchmarking only: with CreateDictionary("big.txt","") and the text corpus from http://norvig.com/big.txt  the Regex below provides the exact same number of dictionary items as Norvigs regex "[a-z]+" (which splits words at apostrophes & incompatible with non-latin characters)     


### PR DESCRIPTION
SymspellCPP was only supported in visual studio.
Now, support for cmake build system is also added.
Some bug fixes are also made.

Signed-off-by: Rajdeep Roy Chowdhury <rajdeep.roychowdhury@lowes.com>