### PR TITLE
Memory leak fix

### DIFF
--- a/include/SymSpell.h
+++ b/include/SymSpell.h
@@ -174,6 +174,8 @@ public:
 		, int prefixLength = DEFAULT_PREFIX_LENGTH, int countThreshold = DEFAULT_COUNT_THRESHOLD
 		, unsigned char compactLevel = DEFAULT_COMPACT_LEVEL);
 
+	~SymSpell();
+
 	/// <summary>Create/Update an entry in the dictionary.</summary>
 	/// <remarks>For every word there are deletes with an edit distance of 1..maxEditDistance created and added to the
 	/// dictionary. Every delete entry has a suggestions list, which points to the original term(s) it was created from.

--- a/src/SymSpell.cpp
+++ b/src/SymSpell.cpp
@@ -65,6 +65,12 @@ SymSpell::SymSpell(int initialCapacity, int maxDictionaryEditDistance
 	this->words = Dictionary<xstring, int64_t>(initialCapacity);
 }
 
+SymSpell::~SymSpell() {
+	if (this->deletes != nullptr) {
+		delete this->deletes;
+	}
+}
+
 /// <summary>Create/Update an entry in the dictionary.</summary>
 /// <remarks>For every word there are deletes with an edit distance of 1..maxEditDistance created and added to the
 /// dictionary. Every delete entry has a suggestions list, which points to the original term(s) it was created from.


### PR DESCRIPTION
The allocated memory under the pointer SymSpell::deletes need to be freed

Signed-off-by: Rajdeep Roy Chowdhury <rajdeep.roychowdhury@lowes.com>