### PR TITLE
fix: null check for deletes added

### DIFF
--- a/src/SymSpell.cpp
+++ b/src/SymSpell.cpp
@@ -485,7 +485,7 @@ vector<SuggestItem> SymSpell::Lookup(xstring input, Verbosity verbosity, int max
 			}
 
 			//read candidate entry from dictionary
-			if (deletes->count(GetstringHash(candidate)))
+			if (deletes != nullptr and deletes->count(GetstringHash(candidate)))
 			{
 				vector<xstring> dictSuggestions = deletes->at(GetstringHash(candidate));
 				//iterate through suggestions (to other correct dictionary items) of delete item and add them to suggestion list


### PR DESCRIPTION
Previously it was throwing a segmentation fault if deletes had a null value.

Signed-off-by: Rajdeep Roy Chowdhury <rajdeep.roychowdhury@lowes.com>